### PR TITLE
Roll back pydantic to 1.x.

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,5 @@
 astral==3.2
 pillow==10.2.0
-pydantic==2.6.0
+pydantic==1.10.14
 python-dotenv==1.0.1
 requests==2.31.0


### PR DESCRIPTION
We have to migrate some code to use pydantic 2.x.